### PR TITLE
Fix rseed argument error on newer version of hyperopt

### DIFF
--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -1,3 +1,4 @@
+import numpy as np
 from hyperopt import fmin
 from .ensemble import VotingModel
 import os
@@ -103,12 +104,20 @@ def base_minimizer(model, data, algo, max_evals, trials, rseed=1337, full_model_
     except OSError:
         pass
 
-    best_run = fmin(keras_fmin_fnct,
-                    space=get_space(),
-                    algo=algo,
-                    max_evals=max_evals,
-                    trials=trials,
-                    rseed=rseed)
+    try:  # for backward compatibility.
+        best_run = fmin(keras_fmin_fnct,
+                        space=get_space(),
+                        algo=algo,
+                        max_evals=max_evals,
+                        trials=trials,
+                        rseed=rseed)
+    except TypeError:
+        best_run = fmin(keras_fmin_fnct,
+                        space=get_space(),
+                        algo=algo,
+                        max_evals=max_evals,
+                        trials=trials,
+                        rstate=np.random.RandomState(rseed))
 
     return best_run
 


### PR DESCRIPTION
The newer version of hyperopt's fmin no longer accepts an integer as a random seed. Instead, it expects a numpy.random.RandomState instance as input.