### PR TITLE
Properly find import statements for the temp model string

### DIFF
--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -77,7 +77,11 @@ def get_hyperopt_model_string(model, data):
     calling_script_file = os.path.abspath(inspect.stack()[-1][1])
     with open(calling_script_file, 'r') as f:
         calling_lines = f.read().split('\n')
-        raw_imports = [line.strip() + "\n" for line in calling_lines if has_raw_import(line)]
+        raw_imports = [
+            "try:\n    %s\nexcept:\n    pass\n" % line.strip()
+            for line in calling_lines
+            if has_raw_import(line)
+        ]
         imports = ''.join(raw_imports)
 
     model_string = [line + "\n" for line in lines if "import" not in line]

--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -107,20 +107,6 @@ def remove_imports(source):
     return '\n'.join(non_import_lines)
 
 
-def extract_and_format_imports(lines):
-    imports = []
-    for line in lines:
-        if has_raw_import(line):
-            if "print_function" in line:
-                # Importing the print_function must be the first line in the the file.
-                # We cannot wrap it in a try/except.
-                imports.append(line.strip() + "\n")
-            else:
-                # Wrap all other imports in try/except, as some python source files do.
-                imports.append("try:\n    %s\nexcept:\n    pass\n" % line.strip())
-    return "".join(imports)
-
-
 def get_hyperopt_model_string(model, data):
     model_string = inspect.getsource(model)
     model_string = remove_imports(model_string)

--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -58,6 +58,17 @@ def best_models(nb_models, model, data, algo, max_evals, trials):
     return model_list
 
 
+# match a string that starts with the keyword `import`, with any indentation
+_starts_with_import = re.compile(r"^\s*\bimport\b")
+
+# match a string that uses the `from .* import .*` syntax, with any indentation
+_has_from_import = re.compile(r"^\s*\bfrom\b.*\bimport\b")
+
+def has_raw_import(line):
+    # Return whether a line in a source file is a valid import statement
+    return bool(_starts_with_import.match(line)) or bool(_has_from_import.match(line))
+
+
 def get_hyperopt_model_string(model, data):
     model_string = inspect.getsource(model)
     lines = model_string.split("\n")
@@ -66,7 +77,7 @@ def get_hyperopt_model_string(model, data):
     calling_script_file = os.path.abspath(inspect.stack()[-1][1])
     with open(calling_script_file, 'r') as f:
         calling_lines = f.read().split('\n')
-        raw_imports = [line.strip() + "\n" for line in calling_lines if "import" in line]
+        raw_imports = [line.strip() + "\n" for line in calling_lines if has_raw_import(line)]
         imports = ''.join(raw_imports)
 
     model_string = [line + "\n" for line in lines if "import" not in line]


### PR DESCRIPTION
This commit partially fixes #18.

When generating the template model file, hyperas includes all lines that contain the word "import". However, some source code files have multiline comments that contain the word "import". Including these lines causes syntax errors in `temp_model.py`. 

For example, hyperas was trying to print the line starting with "importers when locating" into `temp_model.py` from this file: https://svn.python.org/projects/python/trunk/Lib/runpy.py

This PR searches for valid import statements. It's only a partial fix, because we'll still erroneously include a multiline comment like "from file foo, make sure you import bar before running this"
