### PR TITLE
Fix travis.ci build and add python 3.5 (fixes #20)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,16 @@
-sudo: required
 dist: trusty
 language: python
-python:
-  - "2.7"
-  # - "3.4" # Note that hyperopt currently seems to have issues with 3.4
+matrix:
+   include:
+      - python: 2.7
+        env: TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp27-none-linux_x86_64.whl
+      - python: 3.5
+        env: TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp35-cp35m-linux_x86_64.whl
 install:
-  # code below is taken from http://conda.pydata.org/docs/travis.html
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas pytest h5py flask scikit-learn networkx
-  - source activate test-environment
-  - pip install pytest-cov python-coveralls
-  - pip install pymongo==2.7.2
-  - pip install hyperopt
-  - pip install git+git://github.com/Theano/Theano.git
-  - pip install keras
+  - pip install keras hyperopt $TF_BINARY_URL
   - python setup.py install
-
 # Just run an example for now
 script:
-  - python $PWD/examples/simple.py
+  - python examples/simple.py
 after_success:
   - coveralls


### PR DESCRIPTION
This is a rather drastic refactoring of the travis build configuration, but I hope it's acceptable nonetheless. 

- 10  lines instead of 35
- Adds python 3.5
- works