### PR TITLE
Avoid nested Exceptions

### DIFF
--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -74,10 +74,8 @@ def base_minimizer(model, data, algo, max_evals, trials, rseed=1337,
     except OSError:
         pass
 
-    best_run = None
-
     try:  # for backward compatibility.
-        best_run = fmin(keras_fmin_fnct,
+        return fmin(keras_fmin_fnct,
                         space=get_space(),
                         algo=algo,
                         max_evals=max_evals,
@@ -86,15 +84,12 @@ def base_minimizer(model, data, algo, max_evals, trials, rseed=1337,
     except TypeError:
         pass
 
-    if not best_run:
-        best_run = fmin(keras_fmin_fnct,
-                        space=get_space(),
-                        algo=algo,
-                        max_evals=max_evals,
-                        trials=trials,
-                        rstate=np.random.RandomState(rseed))
-
-    return best_run
+    return fmin(keras_fmin_fnct,
+                    space=get_space(),
+                    algo=algo,
+                    max_evals=max_evals,
+                    trials=trials,
+                    rstate=np.random.RandomState(rseed))
 
 
 def best_ensemble(nb_ensemble_models, model, data, algo, max_evals,

--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -74,6 +74,8 @@ def base_minimizer(model, data, algo, max_evals, trials, rseed=1337,
     except OSError:
         pass
 
+    best_run = None
+
     try:  # for backward compatibility.
         best_run = fmin(keras_fmin_fnct,
                         space=get_space(),
@@ -82,6 +84,9 @@ def base_minimizer(model, data, algo, max_evals, trials, rseed=1337,
                         trials=trials,
                         rseed=rseed)
     except TypeError:
+        pass
+
+    if not best_run:
         best_run = fmin(keras_fmin_fnct,
                         space=get_space(),
                         algo=algo,


### PR DESCRIPTION
This improves stack traces lightly by avoiding the nesting.

Before:

```
Train on 717 samples, validate on 180 samples
Epoch 1/1
717/717 [==============================] - 0s - loss: 0.0742 
    mean_absolute_error: 0.0742 - val_loss: 0.0964 - val_mean_absolute_error: 0.0964
   Traceback (most recent call last):
   File "projects/hyperas/hyperas/optim.py", line 83, in base_minimizer
    rseed=rseed)
  TypeError: fmin() got an unexpected keyword argument 'rseed'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "en.py", line 256, in <module>
    best_run = optim.minimize(model, data, tpe.suggest, 50, Trials())
  File "projects/hyperas/hyperas/optim.py", line 42, in minimize
[...]
```

Now:

```Train on 717 samples, validate on 180 samples
Epoch 1/1
717/717 [==============================] - 0s - loss: 0.0742 - mean_absolute_error: 0.0742 - val_loss: 0.0964 - val_mean_absolute_error: 0.0964
Traceback (most recent call last):
  File "en.py", line 256, in <module>
    best_run = optim.minimize(model, data, tpe.suggest, 50, Trials())
  File "projects/hyperas/hyperas/optim.py", line 42, in minimize
   [...]
```