### PR TITLE
Fixed ImportParser "from import as bug"

### DIFF
--- a/hyperas/utils.py
+++ b/hyperas/utils.py
@@ -11,11 +11,9 @@ class ImportParser(ast.NodeVisitor):
         self.line_numbers = []
 
     def visit_Import(self,node):
+        line = 'import {}'.format(self._import_names(node.names))
         if (self._import_asnames(node.names)!=''):
-            line='import {} as {}'.format(self._import_names(node.names),
-       self._import_asnames(node.names) )
-        else:    
-            line = 'import {}'.format(self._import_names(node.names))
+            line += ' as {}'.format(self._import_asnames(node.names) )
         self.line_numbers.append(node.lineno)
         self.lines.append(line)
         
@@ -24,6 +22,10 @@ class ImportParser(ast.NodeVisitor):
             node.level * '.',
             node.module or '',
             self._import_names(node.names))
+
+        if (self._import_asnames(node.names)!=''):
+            line += " as {}".format(self._import_asnames(node.names))
+
         self.line_numbers.append(node.lineno)
         self.lines.append(line)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from hyperas.utils import (
 TEST_SOURCE = """
 from __future__ import print_function
 from sys import path
+from os import walk as walk2
 import os
 import sys # ignore this comment
 ''' remove me '''
@@ -27,6 +28,7 @@ def test_extract_imports():
     assert '_pydev_' not in result
     assert 'try:\n    import os\nexcept:\n    pass\n' in result
     assert 'from sys import path' in result
+    assert 'from os import walk as walk2' in result
     assert 'ignore' not in result
     assert 'remove me' not in result
     assert 'from __future__ import print_function' in result


### PR DESCRIPTION
## Summary
`from module import x as y` were not extracted properly so I wrote a fix and added a test to tests/test_utils

### Description of Problem

If a method contains the source code `from module import x as y`, the previous ImportParser transformed it into `from module import x`, and the `as y` portion was thrown away.

This pull request allows `extract_imports()` to properly extract the full from-import-as statement.

Since `import module as x` statements were already supported, I used the same logic from its `as x` portion and applied it to fix `from module import x as y`.

### Tests

An extra line was added to `TEST_SOURCE` in `tests/test_utils.py` to test the fix and the test is passing.