### PR TITLE
Improved data function last line matching

### DIFF
--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -204,7 +204,8 @@ def get_hyperopt_space(parts, hyperopt_params, verbose=True):
     return space
 
 
-def _retrieve_data_string(data_string, verbose=True):
+def retrieve_data_string(data, verbose=True):
+    data_string = inspect.getsource(data)
     first_line = data_string.split("\n")[0]
     indent_length = len(determine_indent(data_string))
     data_string = data_string.replace(first_line, "")
@@ -220,10 +221,6 @@ def _retrieve_data_string(data_string, verbose=True):
         print(">>> Data")
         print(with_line_numbers(data_string))
     return data_string
-
-
-def retrieve_data_string(data, verbose=True):
-    return _retrieve_data_string(data, verbose=verbose)
 
 
 def retrieve_function_string(functions, verbose=True):

--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -204,12 +204,11 @@ def get_hyperopt_space(parts, hyperopt_params, verbose=True):
     return space
 
 
-def retrieve_data_string(data, verbose=True):
-    data_string = inspect.getsource(data)
+def _retrieve_data_string(data_string, verbose=True):
     first_line = data_string.split("\n")[0]
     indent_length = len(determine_indent(data_string))
     data_string = data_string.replace(first_line, "")
-    r = re.compile('^\s*return.*')
+    r = re.compile(r'^\s*return.*')
     last_line = [s for s in reversed(data_string.split("\n")) if r.match(s)][0]
     data_string = data_string.replace(last_line, "")
 
@@ -221,6 +220,10 @@ def retrieve_data_string(data, verbose=True):
         print(">>> Data")
         print(with_line_numbers(data_string))
     return data_string
+
+
+def retrieve_data_string(data, verbose=True):
+    return _retrieve_data_string(data, verbose=verbose)
 
 
 def retrieve_function_string(functions, verbose=True):

--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -161,7 +161,9 @@ def retrieve_data_string(data, verbose=True):
     first_line = data_string.split("\n")[0]
     indent_length = len(determine_indent(data_string))
     data_string = data_string.replace(first_line, "")
-    data_string = re.sub(r"return.*", "", data_string)
+    r = re.compile('^\s*return.*')
+    last_line = [s for s in reversed(data_string.split("\n")) if r.match(s)][0]
+    data_string = data_string.replace(last_line, "")
 
     split_data = data_string.split("\n")
     for i, line in enumerate(split_data):

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,7 +1,10 @@
-from hyperas.optim import _retrieve_data_string
+from keras.datasets import mnist
+from keras.utils import np_utils
+
+from hyperas.optim import retrieve_data_string
 
 
-TEST_SOURCE_DATA = """def data():
+def test_data():
     (X_train, y_train), (X_test, y_test) = mnist.load_data()
     X_train = X_train.reshape(60000, 784)
     X_test = X_test.reshape(10000, 784)
@@ -13,10 +16,9 @@ TEST_SOURCE_DATA = """def data():
     Y_train = np_utils.to_categorical(y_train, nb_classes_return)
     Y_test = np_utils.to_categorical(y_test, nb_classes_return)
     return X_train, Y_train, X_test, Y_test
-"""
 
 def test_data_function():
-    result = _retrieve_data_string(TEST_SOURCE_DATA, verbose=False)
+    result = retrieve_data_string(test_data, verbose=False)
     assert 'return X_train, Y_train, X_test, Y_test' not in result
     assert 'def data():' not in result
     assert 'nb_classes_return = 10' in result

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,0 +1,27 @@
+from hyperas.optim import _retrieve_data_string
+
+
+TEST_SOURCE_DATA = """def data():
+    (X_train, y_train), (X_test, y_test) = mnist.load_data()
+    X_train = X_train.reshape(60000, 784)
+    X_test = X_test.reshape(10000, 784)
+    X_train = X_train.astype('float32')
+    X_test = X_test.astype('float32')
+    X_train /= 255
+    X_test /= 255
+    nb_classes_return = 10
+    Y_train = np_utils.to_categorical(y_train, nb_classes_return)
+    Y_test = np_utils.to_categorical(y_test, nb_classes_return)
+    return X_train, Y_train, X_test, Y_test
+"""
+
+def test_data_function():
+    result = _retrieve_data_string(TEST_SOURCE_DATA, verbose=False)
+    assert 'return X_train, Y_train, X_test, Y_test' not in result
+    assert 'def data():' not in result
+    assert 'nb_classes_return = 10' in result
+    assert '(X_train, y_train), (X_test, y_test) = mnist.load_data()' in result
+    assert 'Y_test = np_utils.to_categorical(y_test, nb_classes_return)' in result
+
+if __name__ == '__main__':
+    test_data_function()


### PR DESCRIPTION
The original logic was causing problems if 'return' was present in any line, so this update should only remove the first line from the end that starts with 'return'.