### PR TITLE
Resume parameter search from persistent trials

### DIFF
--- a/hyperas/optim.py
+++ b/hyperas/optim.py
@@ -68,9 +68,13 @@ def minimize(model,
     best_model = None
     for trial in trials:
         vals = trial.get('misc').get('vals')
-        for key in vals.keys():
-            vals[key] = vals[key][0]
-        if trial.get('misc').get('vals') == best_run and 'model' in trial.get('result').keys():
+        # unpack the values from lists without overwriting the mutable dict within 'trial'
+        unpacked_vals = {}
+        for k, v in list(vals.items()):
+            if v:
+                unpacked_vals[k] = v[0]
+        # identify the best run (comes with unpacked values from the hyperopt function `base.Trials.argmin`)
+        if unpacked_vals == best_run and 'model' in trial.get('result').keys():
             best_model = trial.get('result').get('model')
 
     if eval_space is True:
@@ -114,7 +118,8 @@ def base_minimizer(model, data, functions, algo, max_evals, trials,
                  algo=algo,
                  max_evals=max_evals,
                  trials=trials,
-                 rseed=rseed),
+                 rseed=rseed,
+                 return_argmin=True),
             get_space()
         )
     except TypeError:
@@ -126,7 +131,8 @@ def base_minimizer(model, data, functions, algo, max_evals, trials,
              algo=algo,
              max_evals=max_evals,
              trials=trials,
-             rstate=np.random.RandomState(rseed)),
+             rstate=np.random.RandomState(rseed),
+             return_argmin=True),
         get_space()
     )
 


### PR DESCRIPTION
Motivated by the discussion on how to [resume the search in the hyperopt space from an existing trials database](https://github.com/hyperopt/hyperopt/issues/267), the current hyperas implementation must be adapted to support this transparently.

The current implementation of identifying the `best_run` to get the `model` from it actually modifies the mutable trials `dict` and unpacks the values from the `hyperopt` dictionary values (which are lists). 
Hence, when persisting the `trials` object outside the `hyperas.optim.minimize` function, it persists with unpacked values. When the `trials` object is loaded again in order to resume the training, `hyperopt` throws an error as it *again* tries to unpack the values from the trials object. This is actually connected to the `hyperopt.fmin` function argument `return_argmin`, which defaults to `True`. 
To add further transparency, this is now explicitly set to `True` in the corresponding function call within `hyperas.optim.base_minimizer`.

Example usage (inspired by [this comment](https://github.com/hyperopt/hyperopt/issues/267#issuecomment-272718758)):
```python
def run_trials():
    """
    Run a number of trials, save after a defined number of iterations.
    """
    trials_step = 1  # how many additional trials to do after loading saved trials. 1 = save after iteration
    max_evals = 5  # initial max_evals. put something small to not have to wait

    try:  
        trials = pickle.load(open('params.hyperopt', 'rb'))
        max_evals = len(trials.trials) + trials_step
        print('Continuing from {} trials to {} (+{}) trials'.format(len(trials.trials), max_evals, trials_step))
    except:
        trials = Trials()
        print('Starting new trials...')

    best, best_model = optim.minimize(
        model=model_fn,
        data=data_fn,
        algo=tpe.suggest,
        max_evals=max_evals,
        trials=trials, 
        eval_space=True
    )

    print("Best:", best)
    
    # save the trials object
    with open("params.hyperopt", "wb") as f:
        pickle.dump(trials, f)

# loop indefinitely and stop whenever you like
while True:
    run_trials()
```
