### PR TITLE
ci: travis build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
   - pip install entrypoints
   - pip install tensorflow
   - pip install --only-binary=numpy,scipy numpy scipy
+  - pip install networkx==1.11
   - python setup.py install
   - pip install pytest pytest-cov pep8 pytest-pep8
 script:


### PR DESCRIPTION
Just adding `pip install networkx==1.11` (known issue) to the `.travis.yml` file for the build to pass