### PR TITLE
Update utils.py to fix comment removal bug

### DIFF
--- a/hyperas/utils.py
+++ b/hyperas/utils.py
@@ -68,7 +68,7 @@ def remove_imports(source):
 
 def remove_all_comments(source):
     string = re.sub(re.compile("'''.*?'''", re.DOTALL), "", source)  # remove '''...''' comments
-    string = re.sub(re.compile("#.*?\n"), "\n", string)  # remove #...\n comments
+    string = re.sub(re.compile("(?<!('|\").)*#[^'\"]*?\n"), "\n", string)  # remove #...\n comments
     return string
 
 


### PR DESCRIPTION
The existing remove_all_comments function incorrectly matches quoted octothorpe characters (#) as comments.
This means that a string like:
```filters='!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~\t\n\'', char_level=False)  # a comment```
is reduced to:
```filters='!"```
Another example:
```test_string = "This is a string containing a # character"```
is reduced to
```test_string = "This is a string containing a ```
The proposed change adds a lookbehind and negative match for single and double quotes.